### PR TITLE
mention the need to disable replaced core plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,23 @@ plugins: [
   require('tailwind-direction').default,
 ],
 ```
+- Disable the following core tailwind plugins (otherwise, utilitites will produce both left and right css rules at the same time)
+
+```js
+corePlugins: {
+  borderRadius: false,
+  borderWidth: false,
+  clear: false,
+  divideWidth: false,
+  float: false,
+  margin: false,
+  padding: false,
+  space: false,
+  textAlign: false,
+  transformOrigin: false,
+},
+```
+
 - Change the html tag `dir` attribute:
 ```html
 <html dir="rtl">

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ corePlugins: {
   clear: false,
   divideWidth: false,
   float: false,
+  inset: false,
   margin: false,
   padding: false,
   space: false,


### PR DESCRIPTION
Add a step under `Usage` to disable the core plugins that this plugin replaces.

Maybe instead of having to list each of these core plugins, the plugin can export a non-default helper object that contains the replaced core plugins?

## Example
```js
// tailwind.config.js
const replacedPlugins = require("tailwind-direction").plugins;

module.exports = {
  ...
  plugins: [
    require('tailwind-direction').default,
  ],
  corePlugins: {
    ...replacedPlugins, // these will have a value of `false`
  },
...
};
```

## Documentation reference
https://tailwindcss.com/docs/configuration#core-plugins