### PR TITLE
Add tailwind preset to disable replaced core plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,23 +22,25 @@ plugins: [
   require('tailwind-direction').default,
 ],
 ```
-- Disable the following core tailwind plugins (otherwise, utilitites will produce both left and right css rules at the same time)
+
+- Extend our configuration preset which disables the core tailwind
+  plugins we replace (otherwise, directional utilitites will produce
+  both left and right css rules at the same time).
 
 ```js
-corePlugins: {
-  borderRadius: false,
-  borderWidth: false,
-  clear: false,
-  divideWidth: false,
-  float: false,
-  inset: false,
-  margin: false,
-  padding: false,
-  space: false,
-  textAlign: false,
-  transformOrigin: false,
-},
+presets: [
+  require("tailwind-direction").configPreset,
+],
 ```
+
+> ⚠ **Warning:** If you are modifing `corePlugins` in your own
+> `tailwind.config.css`, you have to use the object syntax while
+> extending our configuration preset. This is because the array syntax
+> [does not support
+> merging](https://tailwindcss.com/docs/presets#core-plugins) and your
+> own configuration will have priority. If you must use the array syntax
+> you have to manually disable [all the core plugins we
+> replace](https://github.com/sa3dany/tailwind-direction/blob/main/README.md#affected-core-plugins).
 
 - Change the html tag `dir` attribute:
 ```html
@@ -60,17 +62,19 @@ There are two other know packages that solves the same problem:
 - [tailwindcss-rtl](https://github.com/20lives/tailwindcss-rtl): This package takes a different and a better approach, instead of adding new variants, you replace the targeted variants, like `mr`, `rounded-bl`, with it's direction corresponding utilites: `ms`, `rounded-be`
 - [tailwind-direction 🚀](https://github.com/yassinebridi/tailwind-direction): What this package does, is replacing the core utilites, with direction in mind ones, so you can just plug-in this packages and you are done, no refractoring proccess needed.
 
-## Affected core plugins:
+## Affected core plugins
+
 Currently the affected core plugins are:
-- padding
-- margin
-- inset
+
 - borderRadius
 - borderWidth
-- space
-- divide
 - clear
+- divide
 - float
+- inset
+- margin
+- padding
+- space
 - textAlign
 - transformOrigin
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
-import { directionPlugin } from './plugin';
-
-export default directionPlugin;
+export {
+  directionPlugin as default,
+  tailwindPreset as configPreset,
+} from './plugin';

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -23,3 +23,21 @@ export const directionPlugin = ({ addUtilities, theme, variants, e }) => {
   addUtilities(textAlignUtility(), variants('textAlign'));
   addUtilities(transformOriginUtility(), variants('transformOrigin'));
 };
+
+// tailwindcss preset config that disables core plugins we replace.
+// Learn more: https://tailwindcss.com/docs/presets
+export const tailwindPreset = {
+  corePlugins: {
+    borderRadius: false,
+    borderWidth: false,
+    clear: false,
+    divideWidth: false,
+    float: false,
+    inset: false,
+    margin: false,
+    padding: false,
+    space: false,
+    textAlign: false,
+    transformOrigin: false,
+  },
+};


### PR DESCRIPTION
As we discussed in #2, This pull exports a tailwind config preset that disables the core plugins we replace.
I also updated the README to reflect this change.